### PR TITLE
Rainbow stable

### DIFF
--- a/src/boards/rainbow_esp.cpp
+++ b/src/boards/rainbow_esp.cpp
@@ -40,7 +40,7 @@ typedef SSIZE_T ssize_t;
 #endif
 
 #ifndef RAINBOW_DEBUG_ESP
-#define RAINBOW_DEBUG_ESP 2
+#define RAINBOW_DEBUG_ESP 0
 #endif
 
 #if RAINBOW_DEBUG_ESP >= 1


### PR DESCRIPTION
"typo and indent" commit should not be an issue.

The commit to set debug level to zero by default is not the first time I have to do it. I guess you use the logs daily so you tend to set it. Problem for me is, at least on Windows I have no way to force it to a specific value at build time. It would require a profile in the visual studio solution which sets "-D RAINBOW_DEBUG_ESP=0 -D RAINBOW_DEBUG_MAPPER=0" so I can select that profile and don't care about the default.